### PR TITLE
Fix jetty-http lost in ripple-server and ripple-client

### DIFF
--- a/ripple-client/pom.xml
+++ b/ripple-client/pom.xml
@@ -36,6 +36,11 @@
             <version>9.4.54.v20240208</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>9.4.54.v20240208</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.17.2</version>

--- a/ripple-server/pom.xml
+++ b/ripple-server/pom.xml
@@ -36,6 +36,11 @@
             <version>9.4.54.v20240208</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>9.4.54.v20240208</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.17.2</version>


### PR DESCRIPTION
When I ran `mvn install` , I encountered an error indicating that `jetty-http` could not be found. After adding the following code to both [`ripple-server/pom.xml`](https://github.com/ISCAS-SSG/Ripple/blob/master/ripple-server/pom.xml) and [`ripple-client/pom.xml`](https://github.com/ISCAS-SSG/Ripple/blob/master/ripple-client/pom.xml), I was able to correctly download and install `jetty-http`, and successfully run `mvn install`.
```
<dependency>
  <groupId>org.eclipse.jetty</groupId>
  <artifactId>jetty-http</artifactId>
  <version>9.4.54.v20240208</version>
</dependency>
```